### PR TITLE
ci: point Pages deploy trigger at main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,12 @@
 name: Deploy to GitHub Pages
 
 on:
-  # `develop` is the default branch; `master` kept to match the old gh-pages
-  # deploy target. Trim this list to wherever the deployable source lives.
-  # NOTE: repo Settings > Pages > Source must be set to "GitHub Actions" —
-  # if it still points at the legacy gh-pages branch, runs succeed but the
-  # live site never updates.
+  # `main` is the default branch and the deployable source.
+  # NOTE: repo Settings > Pages > Source must be set to "GitHub Actions"
+  # (build_type "workflow"), not a branch, or runs succeed but the live
+  # site never updates.
   push:
-    branches: [develop, master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Follow-up to the develop→main rename and legacy-branch cleanup.

The deploy workflow triggered on `[develop, master]`; `develop` was renamed to `main` and `master`/`gh-pages` are being deleted. This points the trigger at `main` only and updates the stale comment.

No behavior change beyond the branch name. Merging this to `main` will itself fire the first `main`-triggered deploy — verifying the fix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)