### PR TITLE
CI: pin Node 22 for Astro 7 build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,9 +27,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Build Astro site
         uses: withastro/action@v3
-        # with:
-        #   node-version: 20
-        #   package-manager: npm
+        with:
+          # Astro 7 requires Node >=22.12; the action defaults to 20.
+          node-version: 22
+          # package-manager: npm
 
   deploy:
     needs: build


### PR DESCRIPTION
## What

Pins `node-version: 22` in the `withastro/action@v3` build step.

## Why

The Astro 7 upgrade (#37) merged cleanly but the deploy **failed**: `withastro/action@v3` defaults to Node 20, and `astro@7` requires `>=22.12.0` (`Node.js v20.20.2 is not supported by Astro!`). The local build passed only because my local Node is 23.

This pins the CI Node version to 22 so the deploy matches Astro 7's engine requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)